### PR TITLE
Add a scale resize method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    imanip (0.1.4)
+    imanip (0.1.5)
       safe_shell (~> 1.0)
 
 GEM
@@ -10,7 +10,7 @@ GEM
     mocha (0.9.8)
       rake
     rake (0.8.7)
-    safe_shell (1.0.0)
+    safe_shell (1.0.2)
 
 PLATFORMS
   ruby

--- a/lib/imanip/imanip_magick.rb
+++ b/lib/imanip/imanip_magick.rb
@@ -89,21 +89,21 @@ module Imanip
         convert(to_file,crop_resize_string)
       end
       alias :crop_resized :crop_resize
-      
+
       def scale_resize(to_file, options = {})
         @options = options.dup
         parse_size_options!
-        crop_resize_string = ""
-        crop_width = @geometry[:width]
-        crop_height =  @geometry[:height]
+        scale_resize_string = ""
+        preserve_width = @geometry[:width]
+        preserve_height =  @geometry[:height]
         scale_width = @scale[:width]
         scale_height = @scale[:height]
         gravity = @options.delete(:gravity) || 'center'
         background = @options.delete(:background) || 'white'
-        crop_resize_string << " -background #{background} -scale #{to_geometry_string(:height => scale_height, :width => scale_width)} -extent #{to_geometry_string(:height => crop_height, :width => crop_width)}"
-        crop_resize_string << " -gravity #{gravity}"
-        crop_resize_string << " #{options_to_string(@options)}"
-        convert(to_file,crop_resize_string)
+        scale_resize_string << " -background #{background} -scale #{to_geometry_string(:height => preserve_height, :width => preserve_width)} -extent #{to_geometry_string(:height => scale_height, :width => scale_width)}"
+        scale_resize_string << " -gravity #{gravity}"
+        scale_resize_string << " #{options_to_string(@options)}"
+        convert(to_file,scale_resize_string)
       end
 
       def identify(options = {})

--- a/lib/imanip/imanip_magick.rb
+++ b/lib/imanip/imanip_magick.rb
@@ -89,6 +89,22 @@ module Imanip
         convert(to_file,crop_resize_string)
       end
       alias :crop_resized :crop_resize
+      
+      def scale_resize(to_file, options = {})
+        @options = options.dup
+        parse_size_options!
+        crop_resize_string = ""
+        crop_width = @geometry[:width]
+        crop_height =  @geometry[:height]
+        scale_width = @scale[:width]
+        scale_height = @scale[:height]
+        gravity = @options.delete(:gravity) || 'center'
+        background = @options.delete(:background) || 'white'
+        crop_resize_string << " -background #{background} -scale #{to_geometry_string(:height => scale_height, :width => scale_width)} -extent #{to_geometry_string(:height => crop_height, :width => crop_width)}"
+        crop_resize_string << " -gravity #{gravity}"
+        crop_resize_string << " #{options_to_string(@options)}"
+        convert(to_file,crop_resize_string)
+      end
 
       def identify(options = {})
         response = execute("#{execute_path}identify #{options_to_string(options)} #{@image_path}")
@@ -117,6 +133,7 @@ module Imanip
 
       def parse_size_options!
         @geometry = {}
+        @scale = {}
         if @options[:geometry]
           width, height = @options.delete(:geometry).split('x')
           @geometry = {:width => width, :height => height}
@@ -124,6 +141,10 @@ module Imanip
         if @options[:dimensions]
           width, height = @options.delete(:dimensions)
           @geometry = {:width => width, :height => height}
+        end
+        if @options[:scale]
+          width, height = @options.delete(:scale)
+          @scale = {:width => width, :height => height}
         end
         @geometry = {:width => @options.delete(:width), :height => @options.delete(:height) } if @options[:width] || @options[:height]
         @geometry.collect {|d| d[1].to_i unless d.nil? }

--- a/test/test_imanip_magick.rb
+++ b/test/test_imanip_magick.rb
@@ -94,6 +94,20 @@ class ImanipMagickTest < Test::Unit::TestCase
     assert_equal dimensions, @new_image.dimensions
   end
 
+  def test_scale_resize_should_scale_and_resize_image_to_scaled_dimensions
+    dimensions = [400,315]
+    scaled = [600,315]
+    assert @landscape_image.scale_resize(new_image_path, :dimensions => dimensions, :scale => scaled)
+    @new_image = new_imanip_image(new_image_path)
+    assert_equal scaled, @new_image.dimensions
+
+    dimensions = [411,519]
+    scaled = [411,600]
+    assert @portrait_image.scale_resize(new_image_path, :dimensions => dimensions, :scale => scaled)
+    @new_image = new_imanip_image(new_image_path)
+    assert_equal scaled, @new_image.dimensions
+  end
+
   def test_crop_resize_should_crop_and_resize_image_to_exact_dimensions_with_square_dimensions
     dimensions = [100,100]
     assert @landscape_image.crop_resize(new_image_path, :dimensions => dimensions)


### PR DESCRIPTION
This can be used to scale an image preserving the aspect ratio. 
Ex: Scale an image of size 630x630 to 830x630. The new image will have the extra width padded with the background color.
http://www.imagemagick.org/script/command-line-options.php#scale
http://www.imagemagick.org/script/command-line-options.php#extent
